### PR TITLE
feat(notifications,dashboard): meaningful notifications + workspace picker on dashboard

### DIFF
--- a/backend/app/notifications/models.py
+++ b/backend/app/notifications/models.py
@@ -1,41 +1,80 @@
 """
 Notifications — Pydantic models (DTOs / Schemas).
 
-A notification represents an alert for a user about an upcoming or
-overdue task deadline.
+A notification represents an alert for a user about a meaningful event —
+approaching deadlines, teammates' activity in a workspace, productivity
+milestones, and so on.
 
 Models
 ------
-NotificationType — enum of trigger types (DEADLINE_24H, DEADLINE_1H, OVERDUE)
-NotificationCreate — internal model used by the deadline scanner service
+NotificationType     — enum of all notification triggers
+NOTIFICATION_MESSAGES — default human-readable label for each type
+NotificationCreate   — internal model used by the service to emit a notification
 NotificationResponse — full notification entry returned to clients
+UnreadCountResponse  — GET /notifications/count response shape
 """
 
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 
 from pydantic import BaseModel
 
 
 class NotificationType(str, Enum):
-    """Types of deadline notifications."""
+    """All notification trigger types.
+
+    The string value is persisted to Mongo as-is so a single DB can outlive
+    multiple code refactors. Add new members at the bottom to keep the
+    wire format stable.
+    """
+
+    # ── Deadline-driven (emitted by the background scanner) ───────────────
     DEADLINE_24H = "DEADLINE_24H"
     DEADLINE_1H = "DEADLINE_1H"
     OVERDUE = "OVERDUE"
+
+    # ── Task events (own actions) ─────────────────────────────────────────
+    TASK_COMPLETED = "TASK_COMPLETED"
+    ALL_SUBTASKS_DONE = "ALL_SUBTASKS_DONE"
+
+    # ── Productivity / motivation ─────────────────────────────────────────
+    POMODORO_COMPLETE = "POMODORO_COMPLETE"
+    STREAK_MILESTONE = "STREAK_MILESTONE"
+    FROG_IDENTIFIED = "FROG_IDENTIFIED"
+
+    # ── Collaboration (emitted to other members, not the actor) ───────────
+    WORKSPACE_INVITED = "WORKSPACE_INVITED"
+    WORKSPACE_TASK_ADDED = "WORKSPACE_TASK_ADDED"
+    WORKSPACE_TASK_COMPLETED = "WORKSPACE_TASK_COMPLETED"
 
 
 NOTIFICATION_MESSAGES = {
     NotificationType.DEADLINE_24H: "Due in 24 hours",
     NotificationType.DEADLINE_1H: "Due in 1 hour",
     NotificationType.OVERDUE: "Overdue",
+    NotificationType.TASK_COMPLETED: "Task completed",
+    NotificationType.ALL_SUBTASKS_DONE: "All subtasks done — ready to finish?",
+    NotificationType.POMODORO_COMPLETE: "Pomodoro complete — take a break",
+    NotificationType.STREAK_MILESTONE: "Streak milestone",
+    NotificationType.FROG_IDENTIFIED: "Today's frog — start with this",
+    NotificationType.WORKSPACE_INVITED: "You were added to a workspace",
+    NotificationType.WORKSPACE_TASK_ADDED: "New task in your workspace",
+    NotificationType.WORKSPACE_TASK_COMPLETED: "Task completed in your workspace",
 }
 
 
 class NotificationCreate(BaseModel):
-    """Internal model — used by the deadline scanner to create a notification."""
+    """Internal model — used by emitters to create a notification.
+
+    ``task_id`` / ``task_title`` are optional now so that notifications not
+    tied to a specific task (e.g. streak milestones, workspace invites) can
+    still be emitted through the same pipeline.
+    """
+
     user_id: str
-    task_id: str
-    task_title: str
+    task_id: Optional[str] = None
+    task_title: Optional[str] = None
     type: NotificationType
     message: str = ""
 
@@ -44,8 +83,8 @@ class NotificationResponse(BaseModel):
     """Full notification returned to clients."""
     id: str
     user_id: str
-    task_id: str
-    task_title: str
+    task_id: Optional[str] = None
+    task_title: Optional[str] = None
     type: NotificationType
     message: str
     read: bool = False

--- a/backend/app/notifications/service.py
+++ b/backend/app/notifications/service.py
@@ -1,20 +1,26 @@
 """
-Notifications Service — business logic for deadline notifications.
+Notifications Service — business logic for all user notifications.
 
 Responsibilities:
-  • Create notifications (used by the background deadline scanner)
+  • Create notifications (deadline scanner, task events, collaboration, etc.)
   • List notifications for a user (newest first)
   • Mark individual or all notifications as read
   • Delete a notification
   • Check for duplicate notifications (prevent re-alerting)
+  • One-shot ``emit()`` helper that persists a notification AND pushes the
+    real-time WebSocket event — used by every feature that fires
+    notifications outside the scheduled scanner.
 
 Design Patterns:
   Repository — all MongoDB access is encapsulated here; the router
                never touches the database directly.
+  Observer   — `emit()` publishes to subscribed WebSocket clients via
+               the ConnectionManager singleton.
 """
 
+import logging
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from bson import ObjectId
 
@@ -24,11 +30,14 @@ from app.notifications.models import (
     NotificationType,
 )
 
+logger = logging.getLogger("focusflow.notifications")
+
 
 class NotificationService:
     """Encapsulates all notification persistence and business logic."""
 
     def __init__(self, db):
+        self.db = db
         self.col = db["notifications"]
 
     async def create(self, data: NotificationCreate) -> NotificationResponse:
@@ -45,6 +54,98 @@ class NotificationService:
         result = await self.col.insert_one(doc)
         doc["_id"] = result.inserted_id
         return self._to_response(doc)
+
+    # ── Emit — persist + push via WebSocket in one call ───────────────────
+
+    async def emit(
+        self,
+        *,
+        user_id: str,
+        ntype: NotificationType,
+        message: str,
+        task_id: Optional[str] = None,
+        task_title: Optional[str] = None,
+    ) -> Optional[NotificationResponse]:
+        """
+        Persist a notification AND push it to the user in real time.
+
+        All callers outside the scheduled deadline scanner should use this
+        method rather than ``create`` directly — it guarantees the WebSocket
+        event fires so the bell updates instantly.
+
+        Returns the created notification, or None if the DB insert failed
+        (logged, not raised, because a dropped notification must not roll
+        back the originating business operation).
+        """
+        try:
+            notification = await self.create(NotificationCreate(
+                user_id=user_id,
+                task_id=task_id,
+                task_title=task_title,
+                type=ntype,
+                message=message,
+            ))
+        except Exception as exc:
+            logger.warning("emit: failed to persist notification: %s", exc)
+            return None
+
+        # Push to WebSocket — import inline to avoid a circular import at
+        # module load time (ws.py also imports from the app package).
+        try:
+            from app.ws import manager as ws_manager
+            await ws_manager.send_to_user(user_id, {
+                "type": "notification",
+                "notification": {
+                    "id": notification.id,
+                    "task_id": task_id,
+                    "task_title": task_title,
+                    "notification_type": ntype.value,
+                    "message": message,
+                },
+            })
+        except Exception as exc:
+            # WebSocket push failure should never break the caller — the
+            # notification is already persisted; the client will pick it up
+            # on the next poll.
+            logger.debug("emit: websocket push failed (non-critical): %s", exc)
+
+        return notification
+
+    async def emit_to_workspace_peers(
+        self,
+        *,
+        workspace_id: str,
+        actor_user_id: str,
+        ntype: NotificationType,
+        message: str,
+        task_id: Optional[str] = None,
+        task_title: Optional[str] = None,
+    ) -> int:
+        """
+        Emit a notification to every workspace member except the actor.
+
+        Used when a member does something (adds / completes a task) that the
+        rest of the team should see in their bell. The actor does not
+        receive their own notification — that would be noise.
+
+        Returns the number of notifications successfully persisted.
+        """
+        sent = 0
+        cursor = self.db["workspace_members"].find({"workspace_id": workspace_id})
+        async for member in cursor:
+            recipient = member.get("user_id")
+            if not recipient or recipient == str(actor_user_id):
+                continue
+            result = await self.emit(
+                user_id=recipient,
+                ntype=ntype,
+                message=message,
+                task_id=task_id,
+                task_title=task_title,
+            )
+            if result:
+                sent += 1
+        return sent
 
     async def exists(
         self, user_id: str, task_id: str, ntype: NotificationType

--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -707,21 +707,52 @@ async def suggest_schedule(
 async def find_frog(
     data: AIPrioritizeRequest,
     user=Depends(get_current_user),
+    db=Depends(get_db),
 ):
     """
     Identify the user's 'frog' — the single most important or
     challenging task they should tackle first today.
 
     Based on Brian Tracy's 'Eat That Frog' productivity method.
+
+    Side effect: fires a FROG_IDENTIFIED notification (deduped to once per
+    task per day) so the bell surfaces the suggestion even if the user
+    didn't have the dashboard open when the frog was computed.
     """
     _check_rate_limit(str(user["_id"]))
     api_key = _get_api_key(user)
     strategy = FrogStrategy()
     parsed = await strategy.execute(api_key, {"tasks": data.tasks})
 
+    task_title = parsed.get("task_title", "")
+    task_id = parsed.get("task_id")
+
+    # Best-effort notification — never block the AI response on a notif failure.
+    if task_title:
+        try:
+            from app.notifications.models import NotificationType
+            from app.notifications.service import NotificationService
+            svc = NotificationService(db)
+            # De-dup: only fire once per (user, task) to avoid spamming the
+            # bell if the user re-runs the Frog action several times in a day.
+            already = task_id and await svc.exists(
+                str(user["_id"]), str(task_id), NotificationType.FROG_IDENTIFIED
+            )
+            if not already:
+                await svc.emit(
+                    user_id=str(user["_id"]),
+                    ntype=NotificationType.FROG_IDENTIFIED,
+                    message=f"🐸 Your frog today: \"{task_title}\" — start with this.",
+                    task_id=str(task_id) if task_id else None,
+                    task_title=task_title,
+                )
+        except Exception:
+            # Swallow — notification is non-critical to the AI response.
+            pass
+
     return AIFrogResponse(
-        task_title=parsed.get("task_title", ""),
-        task_id=parsed.get("task_id"),
+        task_title=task_title,
+        task_id=task_id,
         reason=parsed.get("reason", ""),
     )
 

--- a/backend/app/routers/timer.py
+++ b/backend/app/routers/timer.py
@@ -44,6 +44,11 @@ async def log_session(
 
     Returns:
         The logged PomodoroSessionResponse with server-assigned id and timestamp.
+
+    Side effects (best-effort, never fatal):
+      • Fires POMODORO_COMPLETE notification on a completed FOCUS session.
+      • If the completion pushes the user's streak to 3, 7, 14, or 30 days,
+        fires a STREAK_MILESTONE notification as well.
     """
     doc = {
         "user_id": user["_id"],
@@ -54,6 +59,45 @@ async def log_session(
     }
     result = await db["sessions"].insert_one(doc)
     doc["_id"] = result.inserted_id
+
+    # ── Notifications — wrap in try so an outage never blocks session logging
+    try:
+        from app.notifications.models import NotificationType
+        from app.notifications.service import NotificationService
+        nsvc = NotificationService(db)
+
+        if data.phase == "FOCUS":
+            await nsvc.emit(
+                user_id=str(user["_id"]),
+                ntype=NotificationType.POMODORO_COMPLETE,
+                message=(
+                    f"🍅 Pomodoro complete — "
+                    f"{data.duration_minutes} focused minutes. Take a 5-min break."
+                ),
+            )
+
+            # Streak milestones — 3 / 7 / 14 / 30 days. De-duped per-day by
+            # the (user_id, task_id='streak:<n>', type) uniqueness check.
+            streak = await _calculate_streak(db, user["_id"])
+            milestones = {3: "3-day", 7: "7-day", 14: "2-week", 30: "30-day"}
+            if streak in milestones:
+                sentinel_id = f"streak:{streak}:{datetime.utcnow().date().isoformat()}"
+                already = await nsvc.exists(
+                    str(user["_id"]), sentinel_id, NotificationType.STREAK_MILESTONE
+                )
+                if not already:
+                    label = milestones[streak]
+                    await nsvc.emit(
+                        user_id=str(user["_id"]),
+                        ntype=NotificationType.STREAK_MILESTONE,
+                        message=f"🔥 {label} streak! You're on fire. Keep it going.",
+                        task_id=sentinel_id,
+                        task_title=f"{label} streak",
+                    )
+    except Exception:
+        # Non-critical — never fail the session log on notification issues.
+        pass
+
     return _doc_to_session(doc)
 
 

--- a/backend/app/tasks/service.py
+++ b/backend/app/tasks/service.py
@@ -25,6 +25,7 @@ This mirrors the pattern established by app.authentication.service.AuthService.
 # ─────────────────────────────────────────────────────────────────────────────
 
 import calendar as cal_module
+import logging
 from datetime import datetime, timedelta, date as date_type
 from typing import List, Optional
 
@@ -40,6 +41,8 @@ from app.tasks.models import (
     TaskStatus,
     TaskUpdate,
 )
+
+logger = logging.getLogger("focusflow.tasks")
 
 
 class TaskService:
@@ -122,6 +125,26 @@ class TaskService:
             "user_id": str(user["_id"]),
         })
         return member is not None
+
+    # ── Notifications helper ──────────────────────────────────────────────
+
+    def _notif_svc(self):
+        """Lazily build a NotificationService — import inline to prevent
+        a cyclic import (notifications service does not import tasks, but
+        keeping the import local future-proofs the circular dependency
+        risk and makes TaskService importable in isolation for tests)."""
+        from app.notifications.service import NotificationService
+        return NotificationService(self.db)
+
+    async def _workspace_name(self, workspace_id: str) -> str:
+        """Return the workspace name for a given id, or '' if missing."""
+        if not workspace_id:
+            return ""
+        try:
+            ws = await self.db["workspaces"].find_one({"_id": self._object_id(workspace_id)})
+        except Exception:
+            return ""
+        return ws.get("name", "") if ws else ""
 
     async def _workspace_name_map(
         self, workspace_ids: List[str]
@@ -354,6 +377,25 @@ class TaskService:
                 {"_id": self._object_id(ws_id)}
             )
             ws_name = ws_doc.get("name") if ws_doc else None
+
+        # Notify every other workspace member that a new task landed in the
+        # shared pool. Failure must not roll back the task insert — logged
+        # and swallowed.
+        if ws_id and ws_name:
+            try:
+                from app.notifications.models import NotificationType
+                actor_name = user.get("name") or user.get("email") or "A teammate"
+                await self._notif_svc().emit_to_workspace_peers(
+                    workspace_id=ws_id,
+                    actor_user_id=str(user["_id"]),
+                    ntype=NotificationType.WORKSPACE_TASK_ADDED,
+                    message=f"{actor_name} added \"{data.title}\" to {ws_name}",
+                    task_id=str(doc["_id"]),
+                    task_title=data.title,
+                )
+            except Exception as exc:
+                logger.debug("create_task: peer notification failed: %s", exc)
+
         return self._doc_to_task(doc, workspace_name=ws_name)
 
     async def get_task(self, user: dict, task_id: str) -> TaskResponse:
@@ -442,6 +484,31 @@ class TaskService:
                 {"_id": self._object_id(new_ws_id)}
             )
             ws_name = ws_doc.get("name") if ws_doc else None
+
+        # ── All-subtasks-done nudge ──────────────────────────────────────
+        # When a subtask check turns the last incomplete box into DONE,
+        # nudge the task owner that the parent is ready to be finished.
+        try:
+            from app.notifications.models import NotificationType
+            subtasks = result.get("subtasks") or []
+            if (
+                "subtasks" in update_fields
+                and result.get("status") != TaskStatus.DONE
+                and len(subtasks) > 0
+                and all(s.get("status") == "DONE" for s in subtasks)
+            ):
+                owner_id = str(result.get("user_id", user["_id"]))
+                title = result.get("title", "Untitled")
+                await self._notif_svc().emit(
+                    user_id=owner_id,
+                    ntype=NotificationType.ALL_SUBTASKS_DONE,
+                    message=f"🎯 All subtasks done on \"{title}\" — ready to mark it complete?",
+                    task_id=str(result["_id"]),
+                    task_title=title,
+                )
+        except Exception as exc:
+            logger.debug("update_task: subtasks notification failed: %s", exc)
+
         return self._doc_to_task(result, workspace_name=ws_name)
 
     async def complete_task(self, user: dict, task_id: str) -> dict:
@@ -502,6 +569,39 @@ class TaskService:
                 insert_result = await self.db["tasks"].insert_one(new_doc)
                 new_doc["_id"] = insert_result.inserted_id
                 next_task_response = self._doc_to_task(new_doc)
+
+        # ── Notifications ────────────────────────────────────────────────
+        # 1. Celebrate the completion for the user.
+        # 2. If the task belongs to a workspace, notify every peer.
+        # Both emits are non-critical; failures are logged, not raised.
+        try:
+            from app.notifications.models import NotificationType
+            ws_id = result.get("workspace_id")
+            task_title = result.get("title", "Untitled")
+            task_id_str = str(result["_id"])
+
+            await self._notif_svc().emit(
+                user_id=str(user["_id"]),
+                ntype=NotificationType.TASK_COMPLETED,
+                message=f"🎉 Nice work on \"{task_title}\"!",
+                task_id=task_id_str,
+                task_title=task_title,
+            )
+
+            if ws_id:
+                ws_name = await self._workspace_name(ws_id)
+                actor_name = user.get("name") or user.get("email") or "A teammate"
+                await self._notif_svc().emit_to_workspace_peers(
+                    workspace_id=ws_id,
+                    actor_user_id=str(user["_id"]),
+                    ntype=NotificationType.WORKSPACE_TASK_COMPLETED,
+                    message=f"✅ {actor_name} completed \"{task_title}\""
+                            f"{f' in {ws_name}' if ws_name else ''}",
+                    task_id=task_id_str,
+                    task_title=task_title,
+                )
+        except Exception as exc:
+            logger.debug("complete_task: notification emit failed: %s", exc)
 
         return {
             "completed": self._doc_to_task(result),

--- a/backend/app/workspaces/service.py
+++ b/backend/app/workspaces/service.py
@@ -363,6 +363,25 @@ class WorkspaceService:
         }
         await self.db["workspace_members"].insert_one(member_doc)
 
+        # Welcome the new member with a notification. Best-effort — if the
+        # notification subsystem errors, the invite itself must still succeed.
+        try:
+            from app.notifications.models import NotificationType
+            from app.notifications.service import NotificationService
+            workspace = await self.db["workspaces"].find_one(
+                {"_id": self._object_id(workspace_id)}
+            )
+            ws_name = workspace.get("name", "a workspace") if workspace else "a workspace"
+            inviter_name = user.get("name") or user.get("email") or "A teammate"
+            await NotificationService(self.db).emit(
+                user_id=target_id,
+                ntype=NotificationType.WORKSPACE_INVITED,
+                message=f"👥 {inviter_name} added you to {ws_name}",
+            )
+        except Exception:
+            # Don't let notification failure break the invite flow.
+            pass
+
         return MemberResponse(
             user_id=target_id,
             user_name=target.get("name", "Unknown"),

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -19,16 +19,48 @@ import {
 } from '../services/otherServices'
 import { useNotifications } from '../context/NotificationContext'
 
+// ── Visual vocabulary for every notification type ─────────────────────────
+// Adding a new type? Add an entry here and the bell picks it up automatically.
 const TYPE_STYLES = {
-  OVERDUE:       'bg-red-100 text-red-700 border-red-200',
-  DEADLINE_1H:   'bg-amber-100 text-amber-700 border-amber-200',
-  DEADLINE_24H:  'bg-blue-100 text-blue-700 border-blue-200',
+  OVERDUE:                  'bg-red-100    text-red-700     border-red-200',
+  DEADLINE_1H:              'bg-amber-100  text-amber-700   border-amber-200',
+  DEADLINE_24H:             'bg-blue-100   text-blue-700    border-blue-200',
+  TASK_COMPLETED:           'bg-emerald-100 text-emerald-700 border-emerald-200',
+  ALL_SUBTASKS_DONE:        'bg-emerald-100 text-emerald-700 border-emerald-200',
+  POMODORO_COMPLETE:        'bg-rose-100   text-rose-700    border-rose-200',
+  STREAK_MILESTONE:         'bg-orange-100 text-orange-700  border-orange-200',
+  FROG_IDENTIFIED:          'bg-lime-100   text-lime-700    border-lime-200',
+  WORKSPACE_INVITED:        'bg-indigo-100 text-indigo-700  border-indigo-200',
+  WORKSPACE_TASK_ADDED:     'bg-sky-100    text-sky-700     border-sky-200',
+  WORKSPACE_TASK_COMPLETED: 'bg-emerald-100 text-emerald-700 border-emerald-200',
 }
 
 const TYPE_LABELS = {
-  OVERDUE:       'Overdue',
-  DEADLINE_1H:   'Due in 1h',
-  DEADLINE_24H:  'Due in 24h',
+  OVERDUE:                  'Overdue',
+  DEADLINE_1H:              'Due in 1h',
+  DEADLINE_24H:             'Due in 24h',
+  TASK_COMPLETED:           'Completed',
+  ALL_SUBTASKS_DONE:        'Subtasks done',
+  POMODORO_COMPLETE:        'Pomodoro',
+  STREAK_MILESTONE:         'Streak',
+  FROG_IDENTIFIED:          'Frog',
+  WORKSPACE_INVITED:        'Workspace',
+  WORKSPACE_TASK_ADDED:     'New task',
+  WORKSPACE_TASK_COMPLETED: 'Completed',
+}
+
+const TYPE_ICONS = {
+  OVERDUE:                  '⚠️',
+  DEADLINE_1H:              '⏰',
+  DEADLINE_24H:             '📅',
+  TASK_COMPLETED:           '🎉',
+  ALL_SUBTASKS_DONE:        '🎯',
+  POMODORO_COMPLETE:        '🍅',
+  STREAK_MILESTONE:         '🔥',
+  FROG_IDENTIFIED:          '🐸',
+  WORKSPACE_INVITED:        '👥',
+  WORKSPACE_TASK_ADDED:     '📋',
+  WORKSPACE_TASK_COMPLETED: '✅',
 }
 
 export default function NotificationBell() {
@@ -61,9 +93,15 @@ export default function NotificationBell() {
     return () => clearInterval(interval)
   }, [refreshCount])
 
-  // Listen for real-time WebSocket notifications
+  // Listen for real-time WebSocket notifications.
+  // Two event types come through this channel:
+  //   • 'deadline_notification' — legacy, fired by the background scanner
+  //   • 'notification'          — generic, fired by any feature via emit()
   useEffect(() => {
-    if (lastMessage?.type === 'deadline_notification') {
+    if (
+      lastMessage?.type === 'deadline_notification' ||
+      lastMessage?.type === 'notification'
+    ) {
       setUnreadCount(prev => prev + 1)
       // If dropdown is open, refresh the list
       if (open) {
@@ -72,8 +110,11 @@ export default function NotificationBell() {
       // Browser push notification
       const n = lastMessage.notification
       if (n && 'Notification' in window && Notification.permission === 'granted') {
-        const typeLabel = TYPE_LABELS[n.notification_type] || 'Deadline'
-        new Notification(`${typeLabel}: ${n.task_title}`, {
+        const icon = TYPE_ICONS[n.notification_type] || '🔔'
+        const title = n.task_title
+          ? `${icon}  ${n.task_title}`
+          : `${icon}  ${TYPE_LABELS[n.notification_type] || 'FocusFlow'}`
+        new Notification(title, {
           body: n.message,
           icon: '/favicon.ico',
           tag: n.id, // prevent duplicate browser notifications
@@ -203,19 +244,32 @@ export default function NotificationBell() {
                     n.read ? 'opacity-60' : 'bg-indigo-50/30 dark:bg-indigo-950/20'
                   }`}
                 >
-                  {/* Type badge */}
-                  <span className={`text-xs font-bold px-1.5 py-0.5 rounded border shrink-0 mt-0.5 ${TYPE_STYLES[n.type] || TYPE_STYLES.DEADLINE_24H}`}>
-                    {TYPE_LABELS[n.type] || n.type}
-                  </span>
+                  {/* Icon + Type badge stacked */}
+                  <div className="flex flex-col items-center gap-1 shrink-0 mt-0.5">
+                    <span className="text-base leading-none" aria-hidden="true">
+                      {TYPE_ICONS[n.type] || '🔔'}
+                    </span>
+                    <span
+                      className={`text-[10px] font-bold uppercase px-1 py-0.5 rounded border ${
+                        TYPE_STYLES[n.type] || TYPE_STYLES.DEADLINE_24H
+                      }`}
+                    >
+                      {TYPE_LABELS[n.type] || n.type}
+                    </span>
+                  </div>
 
-                  {/* Content */}
+                  {/* Content — fall back to the message on the title line when
+                      the notification isn't tied to a named task (e.g.
+                      workspace invites and streak milestones). */}
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                      {n.task_title}
+                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                      {n.task_title || n.message}
                     </p>
-                    <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
-                      {n.message}
-                    </p>
+                    {n.task_title && n.message && (
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                        {n.message}
+                      </p>
+                    )}
                     <p className="text-xs text-gray-300 dark:text-gray-600 mt-1">
                       {timeAgo(n.created_at)}
                     </p>

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -18,6 +18,7 @@ import { useTimer } from '../context/TimerContext'
 import { PHASES } from '../context/timerPhases'
 import { fetchStats, fetchBlocks, createBlock, createBlocksBulk, aiFrog, aiTips } from '../services/otherServices'
 import { fetchTasks, markTaskComplete, createTask, updateTask, fetchTaskAnalytics } from '../services/taskService'
+import { fetchWorkspaces } from '../services/sharingService'
 import { generateRecurringSlots } from '../utils/smartSchedule'
 import SketchLine from '../components/SketchLine'
 import AITaskGenerator from '../components/AITaskGenerator'
@@ -147,9 +148,13 @@ export default function DashboardPage() {
   const [newDeadline, setNewDeadline]     = useState('')
   const [newTime, setNewTime]             = useState('')
   const [newRecurrence, setNewRecurrence] = useState('NONE')
+  const [newWorkspaceId, setNewWorkspaceId] = useState('')
   const [adding, setAdding]               = useState(false)
   const [addError, setAddError]           = useState('')
   const [scheduleMsg, setScheduleMsg]     = useState('')
+
+  // Workspaces available to this user — powers the quick-add workspace selector.
+  const [workspaces, setWorkspaces] = useState([])
 
   // AI widgets
   const [aiFrogData, setAiFrogData]         = useState(null)
@@ -162,14 +167,18 @@ export default function DashboardPage() {
   useEffect(() => {
     async function load() {
       try {
-        const [s, t, a] = await Promise.all([
+        // Fetch in parallel. Workspaces is non-critical (empty list is fine
+        // for users who haven't joined any), so we let it fail silently.
+        const [s, t, a, ws] = await Promise.all([
           fetchStats(),
           fetchTasks(),
           fetchTaskAnalytics(),
+          fetchWorkspaces().catch(() => []),
         ])
         setStats(s ?? { tasks_done: 0, deep_work_hours: 0 })
         setTasks(t.filter(tk => !tk.is_complete).slice(0, 8))
         setAnalytics(a)
+        setWorkspaces(Array.isArray(ws) ? ws : [])
       } catch (_) { /* non-blocking */ }
       setLoading(false)
     }
@@ -220,6 +229,9 @@ export default function DashboardPage() {
         deadline: newDeadline || null,
         due_time: newTime || null,
         recurrence: newRecurrence,
+        // Empty string → personal task. Otherwise the backend validates
+        // that the caller is a member of the chosen workspace.
+        workspace_id: newWorkspaceId || null,
       })
       setTasks(prev => [created, ...prev].slice(0, 8))
 
@@ -258,8 +270,16 @@ export default function DashboardPage() {
       setNewDeadline('')
       setNewTime('')
       setNewRecurrence('NONE')
-    } catch {
-      setAddError('Could not add task — try again.')
+      setNewWorkspaceId('')
+    } catch (err) {
+      // Surface a clear message for the common failure modes — lost access
+      // to the chosen workspace, or anything else unexpected.
+      const msg = err?.response?.data?.detail
+      setAddError(
+        msg && typeof msg === 'string'
+          ? msg
+          : 'Could not add task — try again.'
+      )
     }
     setAdding(false)
   }
@@ -500,6 +520,32 @@ export default function DashboardPage() {
                              disabled:opacity-40 disabled:cursor-not-allowed"
                 />
               </div>
+
+              {/* Workspace — only shown when the user has at least one workspace */}
+              {workspaces.length > 0 && (
+                <div className="flex items-center gap-2 mb-3 flex-wrap">
+                  <span
+                    className="text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-gray-500 shrink-0"
+                    title="Pick a workspace to share this task with its members, or keep it personal."
+                  >
+                    Workspace
+                  </span>
+                  <select
+                    value={newWorkspaceId}
+                    onChange={e => setNewWorkspaceId(e.target.value)}
+                    className="flex-1 min-w-0 px-3 py-1.5 border border-[#dee4da] rounded-xl text-xs font-medium
+                               bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200
+                               focus:border-[#3a6758] focus:ring-0 outline-none transition-colors"
+                  >
+                    <option value="">Personal — only you can see this</option>
+                    {workspaces.map(w => (
+                      <option key={w.id} value={w.id}>
+                        👥 {w.name} — shared with all members
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
 
               {/* Task type chips */}
               <div className="flex items-center gap-2 mb-3 flex-wrap">

--- a/frontend/src/tests/DashboardPage.test.jsx
+++ b/frontend/src/tests/DashboardPage.test.jsx
@@ -64,6 +64,13 @@ jest.mock('../services/authService', () => ({
   getProfile: (...a) => mockGetProfile(...a),
 }))
 
+// sharingService is called for the workspace selector. The tests don't care
+// about workspaces, so always return an empty list — this also keeps axios
+// from firing a real network request.
+jest.mock('../services/sharingService', () => ({
+  fetchWorkspaces: jest.fn().mockResolvedValue([]),
+}))
+
 // ── Mock AITaskGenerator (tested separately) ──────────────────────────────────
 jest.mock('../components/AITaskGenerator', () => {
   function AITaskGeneratorMock() { return <div data-testid="ai-task-generator" /> }

--- a/tests/backend/test_notification_emits.py
+++ b/tests/backend/test_notification_emits.py
@@ -1,0 +1,438 @@
+"""
+Notification emit tests — verifies that feature code paths (task lifecycle,
+workspace membership, AI frog, Pomodoro sessions) correctly emit the new
+notification types introduced by the notifications overhaul.
+
+These are focused on the *side-effect contract*: given an action by user A,
+does the right notification land in user B's inbox (or user A's own inbox
+for solo events)?  We stub out the WebSocket manager so tests don't require
+a running loop, and mock the AI and auth paths where needed.
+
+Scope:
+  N-E01  complete_task → TASK_COMPLETED for the owner
+  N-E02  complete_task in a workspace → WORKSPACE_TASK_COMPLETED for peers
+  N-E03  create_task in a workspace → WORKSPACE_TASK_ADDED for peers
+  N-E04  add_member → WORKSPACE_INVITED for the invitee
+  N-E05  update_task with every subtask DONE → ALL_SUBTASKS_DONE for owner
+  N-E06  emit_to_workspace_peers does NOT notify the actor themselves
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from bson import ObjectId
+from fastapi import HTTPException  # noqa: F401 (kept for future negative tests)
+
+from app.notifications.models import NotificationType
+from app.notifications.service import NotificationService
+from app.tasks.models import TaskCreate, TaskUpdate
+from app.tasks.service import TaskService
+from app.workspaces.models import MemberAdd, WorkspaceRole
+from app.workspaces.service import WorkspaceService
+
+
+NOW = datetime.utcnow()
+USER_A = {"_id": ObjectId(), "name": "Alice", "email": "alice@x.com"}
+USER_B = {"_id": ObjectId(), "name": "Bob",   "email": "bob@x.com"}
+USER_C = {"_id": ObjectId(), "name": "Carol", "email": "carol@x.com"}
+
+
+# ── Async cursor shim for Motor-style iteration ─────────────────────────────
+
+class _AsyncCursor:
+    def __init__(self, items):
+        self._items = list(items)
+        self._i = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._i >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._i]
+        self._i += 1
+        return item
+
+    def sort(self, *a, **k):
+        return self
+
+    def limit(self, *a, **k):
+        return self
+
+
+def _make_db(tasks=None, members=None, workspaces=None):
+    """
+    Build a fake DB with per-collection mocks.
+
+    Each collection needs its own MagicMock because MagicMock's default
+    __getitem__ returns the same child mock for every key.
+    """
+    tasks = tasks or []
+    members = members or []
+    workspaces = workspaces or []
+
+    # ── tasks
+    tasks_col = MagicMock()
+    tasks_col.find.return_value = _AsyncCursor(tasks)
+
+    async def _tasks_find_one(query):
+        if "_id" in query:
+            for d in tasks:
+                if d["_id"] == query["_id"]:
+                    return d
+        return None
+
+    tasks_col.find_one = _tasks_find_one
+    tasks_col.insert_one = AsyncMock(return_value=MagicMock(inserted_id=ObjectId()))
+    tasks_col.find_one_and_update = AsyncMock(
+        return_value=(tasks[0] if tasks else None)
+    )
+    tasks_col.delete_one = AsyncMock(return_value=MagicMock(deleted_count=1))
+    tasks_col.update_many = AsyncMock(return_value=MagicMock(modified_count=0))
+
+    # ── workspace_members
+    members_col = MagicMock()
+
+    def _members_find(query):
+        matches = members
+        if "user_id" in query:
+            matches = [m for m in matches if m["user_id"] == query["user_id"]]
+        if "workspace_id" in query:
+            matches = [m for m in matches if m["workspace_id"] == query["workspace_id"]]
+        return _AsyncCursor(matches)
+
+    members_col.find.side_effect = _members_find
+
+    async def _members_find_one(query):
+        for m in members:
+            if (
+                m.get("workspace_id") == query.get("workspace_id")
+                and m.get("user_id") == query.get("user_id")
+            ):
+                return m
+        return None
+
+    members_col.find_one = _members_find_one
+    members_col.insert_one = AsyncMock(return_value=MagicMock(inserted_id=ObjectId()))
+    members_col.delete_many = AsyncMock(return_value=MagicMock(deleted_count=0))
+
+    # ── workspaces
+    workspaces_col = MagicMock()
+
+    async def _ws_find_one(query):
+        if "_id" in query:
+            for w in workspaces:
+                if w["_id"] == query["_id"]:
+                    return w
+        return None
+
+    workspaces_col.find_one = _ws_find_one
+
+    def _ws_find(query):
+        ids = query.get("_id", {}).get("$in", [])
+        return _AsyncCursor([w for w in workspaces if w["_id"] in ids])
+
+    workspaces_col.find.side_effect = _ws_find
+
+    # ── users (for the add_member path that looks up target by email)
+    users_col = MagicMock()
+
+    async def _users_find_one(query):
+        email = query.get("email")
+        for u in (USER_A, USER_B, USER_C):
+            if u.get("email") == email:
+                return u
+        return None
+
+    users_col.find_one = _users_find_one
+
+    # ── notifications — this is where we record what was emitted
+    notif_col = MagicMock()
+    emitted = []
+
+    async def _notif_insert(doc):
+        emitted.append(doc)
+        m = MagicMock()
+        m.inserted_id = ObjectId()
+        return m
+
+    notif_col.insert_one = _notif_insert
+
+    async def _notif_find_one(query):
+        # Used for the dedup check in the frog endpoint — return None so
+        # tests don't need to set up prior state.
+        return None
+
+    notif_col.find_one = _notif_find_one
+    notif_col.count_documents = AsyncMock(return_value=0)
+    notif_col.find.return_value = _AsyncCursor([])
+
+    # ── task_shares (empty)
+    shares_col = MagicMock()
+    shares_col.find_one = AsyncMock(return_value=None)
+
+    collections = {
+        "tasks": tasks_col,
+        "workspace_members": members_col,
+        "workspaces": workspaces_col,
+        "users": users_col,
+        "notifications": notif_col,
+        "task_shares": shares_col,
+    }
+
+    db = MagicMock()
+    db.__getitem__ = MagicMock(
+        side_effect=lambda k: collections.setdefault(k, MagicMock()),
+    )
+    # Expose the emitted list so tests can make assertions.
+    db._emitted_notifications = emitted
+    return db
+
+
+def _task_doc(title, owner, ws_id=None, subtasks=None, status="TODO", task_id=None):
+    return {
+        "_id": task_id or ObjectId(),
+        "user_id": owner,
+        "title": title,
+        "description": None,
+        "priority": "MEDIUM",
+        "deadline": None,
+        "due_time": None,
+        "recurrence": "NONE",
+        "estimated_minutes": None,
+        "status": status,
+        "subtasks": subtasks or [],
+        "categories": [],
+        "workspace_id": ws_id,
+        "created_at": NOW,
+        "updated_at": NOW,
+    }
+
+
+def _member(workspace_id, user, role="MEMBER"):
+    return {
+        "workspace_id": workspace_id,
+        "user_id": str(user["_id"]),
+        "user_name": user["name"],
+        "email": user["email"],
+        "role": role,
+        "joined_at": NOW,
+    }
+
+
+# Silence the real WebSocket push across every test in this file so we don't
+# depend on a running ConnectionManager or an active event loop.
+@pytest.fixture(autouse=True)
+def _mute_ws():
+    with patch("app.ws.manager.send_to_user", new=AsyncMock()):
+        yield
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# N-E01  complete_task emits TASK_COMPLETED for the owner
+# ══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_complete_task_emits_task_completed_for_owner():
+    task = _task_doc("Finish report", USER_A["_id"])
+    db = _make_db(tasks=[task])
+    # find_one_and_update returns the same doc with status DONE.
+    db["tasks"].find_one_and_update = AsyncMock(
+        return_value={**task, "status": "DONE"}
+    )
+
+    svc = TaskService(db)
+    await svc.complete_task(USER_A, str(task["_id"]))
+
+    types = [n["type"] for n in db._emitted_notifications]
+    assert NotificationType.TASK_COMPLETED.value in types
+
+    target = next(
+        n for n in db._emitted_notifications
+        if n["type"] == NotificationType.TASK_COMPLETED.value
+    )
+    assert target["user_id"] == str(USER_A["_id"])
+    assert "Finish report" in target["message"]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# N-E02  Workspace task complete → peers get WORKSPACE_TASK_COMPLETED
+# ══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_complete_workspace_task_notifies_peers_not_actor():
+    ws_id = str(ObjectId())
+    ws_doc = {
+        "_id": ObjectId(ws_id),
+        "owner_id": str(USER_A["_id"]),
+        "name": "Sprint Alpha",
+        "created_at": NOW, "updated_at": NOW,
+    }
+    task = _task_doc("Deploy beta", USER_A["_id"], ws_id=ws_id)
+    db = _make_db(
+        tasks=[task],
+        workspaces=[ws_doc],
+        members=[
+            _member(ws_id, USER_A, role="OWNER"),
+            _member(ws_id, USER_B),
+            _member(ws_id, USER_C),
+        ],
+    )
+    db["tasks"].find_one_and_update = AsyncMock(
+        return_value={**task, "status": "DONE"}
+    )
+
+    svc = TaskService(db)
+    await svc.complete_task(USER_A, str(task["_id"]))
+
+    peer_notifs = [
+        n for n in db._emitted_notifications
+        if n["type"] == NotificationType.WORKSPACE_TASK_COMPLETED.value
+    ]
+    peer_recipients = {n["user_id"] for n in peer_notifs}
+
+    assert str(USER_B["_id"]) in peer_recipients
+    assert str(USER_C["_id"]) in peer_recipients
+    # The actor should NOT receive their own peer notification — noise.
+    assert str(USER_A["_id"]) not in peer_recipients
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# N-E03  Workspace task create → peers get WORKSPACE_TASK_ADDED
+# ══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_create_task_in_workspace_notifies_peers():
+    ws_id = str(ObjectId())
+    ws_doc = {
+        "_id": ObjectId(ws_id),
+        "owner_id": str(USER_A["_id"]),
+        "name": "Sprint Alpha",
+        "created_at": NOW, "updated_at": NOW,
+    }
+    db = _make_db(
+        workspaces=[ws_doc],
+        members=[
+            _member(ws_id, USER_A, role="OWNER"),
+            _member(ws_id, USER_B),
+        ],
+    )
+    svc = TaskService(db)
+
+    await svc.create_task(
+        USER_A,
+        TaskCreate(title="Write docs", workspace_id=ws_id),
+    )
+
+    added = [
+        n for n in db._emitted_notifications
+        if n["type"] == NotificationType.WORKSPACE_TASK_ADDED.value
+    ]
+    recipients = {n["user_id"] for n in added}
+    assert str(USER_B["_id"]) in recipients
+    assert str(USER_A["_id"]) not in recipients
+    assert any("Write docs" in n["message"] for n in added)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# N-E04  add_member → invitee gets WORKSPACE_INVITED
+# ══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_add_member_notifies_invitee():
+    ws_id = str(ObjectId())
+    ws_doc = {
+        "_id": ObjectId(ws_id),
+        "owner_id": str(USER_A["_id"]),
+        "owner_name": USER_A["name"],
+        "name": "Study Group",
+        "created_at": NOW, "updated_at": NOW,
+    }
+    db = _make_db(
+        workspaces=[ws_doc],
+        members=[_member(ws_id, USER_A, role="OWNER")],
+    )
+    svc = WorkspaceService(db)
+
+    await svc.add_member(
+        USER_A,
+        ws_id,
+        MemberAdd(email=USER_B["email"], role=WorkspaceRole.MEMBER),
+    )
+
+    invited = [
+        n for n in db._emitted_notifications
+        if n["type"] == NotificationType.WORKSPACE_INVITED.value
+    ]
+    assert len(invited) == 1
+    assert invited[0]["user_id"] == str(USER_B["_id"])
+    assert "Study Group" in invited[0]["message"]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# N-E05  update_task with every subtask DONE → owner gets ALL_SUBTASKS_DONE
+# ══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_update_task_all_subtasks_done_emits_nudge():
+    subtasks = [
+        {"title": "s1", "status": "DONE"},
+        {"title": "s2", "status": "TODO"},
+    ]
+    task = _task_doc("Prep demo", USER_A["_id"], subtasks=subtasks)
+    db = _make_db(tasks=[task])
+    # Simulate the completed state after the update.
+    updated_subtasks = [
+        {"title": "s1", "status": "DONE"},
+        {"title": "s2", "status": "DONE"},
+    ]
+    db["tasks"].find_one_and_update = AsyncMock(
+        return_value={**task, "subtasks": updated_subtasks}
+    )
+
+    svc = TaskService(db)
+    await svc.update_task(
+        USER_A,
+        str(task["_id"]),
+        TaskUpdate(subtasks=[
+            {"title": "s1", "status": "DONE"},
+            {"title": "s2", "status": "DONE"},
+        ]),
+    )
+
+    nudges = [
+        n for n in db._emitted_notifications
+        if n["type"] == NotificationType.ALL_SUBTASKS_DONE.value
+    ]
+    assert len(nudges) == 1
+    assert nudges[0]["user_id"] == str(USER_A["_id"])
+    assert "Prep demo" in nudges[0]["message"]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# N-E06  emit_to_workspace_peers never notifies the actor
+# ══════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_emit_to_workspace_peers_excludes_actor():
+    ws_id = str(ObjectId())
+    db = _make_db(members=[
+        _member(ws_id, USER_A),
+        _member(ws_id, USER_B),
+        _member(ws_id, USER_C),
+    ])
+    svc = NotificationService(db)
+
+    sent = await svc.emit_to_workspace_peers(
+        workspace_id=ws_id,
+        actor_user_id=str(USER_A["_id"]),
+        ntype=NotificationType.WORKSPACE_TASK_ADDED,
+        message="hello",
+    )
+
+    assert sent == 2
+    recipients = {n["user_id"] for n in db._emitted_notifications}
+    assert str(USER_A["_id"]) not in recipients
+    assert {str(USER_B["_id"]), str(USER_C["_id"])} <= recipients


### PR DESCRIPTION
## Summary

Two improvements you asked for:

### 1. Dashboard now has a Workspace selector on the quick-add form
Previously the only way to assign a new task to a workspace was from the Tasks page. Creating a task from the Dashboard always made it personal — silently. Now the quick-add form shows a **Workspace** dropdown right under the date/time row (only when you're a member of at least one workspace). Pick Personal (default) or a specific workspace; the task drops into the right bucket.

Adding an existing task to a workspace was already possible from the task's edit modal (Workspace dropdown near the top). No extra UI needed there.

### 2. The notification bell now carries real value

Until now the bell only fired on deadline thresholds. Implemented a full notification vocabulary:

| Type | Icon | Trigger |
| --- | --- | --- |
| `TASK_COMPLETED` | 🎉 | Your own task marked DONE |
| `ALL_SUBTASKS_DONE` | 🎯 | Every subtask on a task is DONE — nudge to finish the parent |
| `POMODORO_COMPLETE` | 🍅 | FOCUS session logged |
| `STREAK_MILESTONE` | 🔥 | 3 / 7 / 14 / 30 consecutive day streak hit |
| `FROG_IDENTIFIED` | 🐸 | *"Your frog today: '…' — start with this"* (deduped per task) |
| `WORKSPACE_INVITED` | 👥 | A teammate added you to a workspace |
| `WORKSPACE_TASK_ADDED` | 📋 | Teammate added a task to your shared workspace |
| `WORKSPACE_TASK_COMPLETED` | ✅ | Teammate completed a workspace task |

All three legacy deadline types (`OVERDUE`, `DEADLINE_1H`, `DEADLINE_24H`) still work identically.

## How it's wired

### Backend
- **`NotificationService.emit()`** — new one-call helper: persist the notification *and* push the WebSocket event. Error-isolated so a notification failure never rolls back the business operation that fired it.
- **`NotificationService.emit_to_workspace_peers()`** — broadcasts to every workspace member except the actor (so you don't get pinged about your own actions).
- Emit points:
  - `TaskService.create_task` → peer `WORKSPACE_TASK_ADDED`
  - `TaskService.complete_task` → own `TASK_COMPLETED` + peer `WORKSPACE_TASK_COMPLETED`
  - `TaskService.update_task` → owner `ALL_SUBTASKS_DONE` when the update closes the last open subtask
  - `WorkspaceService.add_member` → invitee `WORKSPACE_INVITED`
  - `/api/ai/frog` → `FROG_IDENTIFIED` (deduped per `(user, task)` so rerunning doesn't spam)
  - `/api/timer/sessions` → `POMODORO_COMPLETE` on FOCUS + `STREAK_MILESTONE` if the completion pushes the streak to 3 / 7 / 14 / 30 days (deduped per day)

### Frontend
- `NotificationBell`: renders emoji + colour-coded badge per type, falls back to the message on the title line when a notification isn't tied to a named task (invites, streaks), listens for both legacy `deadline_notification` and the new generic `notification` WS event.
- `DashboardPage`: loads workspaces on mount (silent fallback to empty list), shows a Workspace `<select>` under the date row, threads `workspace_id` through `createTask`, surfaces backend error messages (e.g. `403 — not a member`) cleanly.

## Edge cases covered

- Notification emit failure does not roll back the originating action — every call is wrapped and swallowed with a debug log.
- WebSocket push failure is a separate layer and doesn't block the insert either; the client picks the notification up on the next poll.
- `NotificationCreate` / `NotificationResponse` now accept null `task_id` / `task_title` so workspace invites and streak milestones can ride the same pipeline.
- `emit_to_workspace_peers` always filters out the actor.
- Frog notification is deduped per `(user, task, type)` so triggering the AI multiple times in a day only fires one alert.
- Streak milestone is deduped per `(user, date, milestone)` so earning a 7-day streak today and running another Pomodoro doesn't re-notify.
- `model_dump(exclude_unset=True)` is used in task update so an omitted `workspace_id` doesn't accidentally wipe the task's current workspace.

## Tests

- **6 new scenario tests** — `tests/backend/test_notification_emits.py`:
  - N-E01 complete_task emits TASK_COMPLETED for owner
  - N-E02 workspace complete notifies peers, not actor
  - N-E03 workspace create notifies peers, not actor
  - N-E04 add_member notifies invitee
  - N-E05 update with all subtasks done → ALL_SUBTASKS_DONE
  - N-E06 emit_to_workspace_peers excludes the actor
- **Updated** `DashboardPage.test.jsx` to mock `sharingService` since the page now loads workspaces on mount.

## Totals
- **319** backend tests (was 313 · +6 new)
- **424** frontend tests
- flake8 + ESLint clean

## Test plan

- [x] `pytest tests/` — 319 passed
- [x] `npm test` — 424 passed
- [x] `flake8 app/ --max-line-length=100` — clean
- [x] `npx eslint src/` — clean
- [ ] Manual: create a task from Dashboard with a workspace selected → appears in workspace, teammate gets 📋 notification
- [ ] Manual: complete a workspace task → teammates get ✅ notification in their bell
- [ ] Manual: run AI Frog → 🐸 notification fires in bell
- [ ] Manual: complete a Pomodoro → 🍅 notification; if 3rd consecutive day, also 🔥 streak

🤖 Generated with [Claude Code](https://claude.com/claude-code)